### PR TITLE
[storybook__addon-knobs] Add missing type overload for optionsKnob

### DIFF
--- a/types/storybook__addon-knobs/index.d.ts
+++ b/types/storybook__addon-knobs/index.d.ts
@@ -85,6 +85,15 @@ export function optionsKnob<T>(
     options?: OptionsKnobOptions
 ): T;
 
+export function optionsKnob<T>(
+    label: string,
+    values: {
+        [key: string]: T;
+    },
+    defaultValue?: T[],
+    options?: OptionsKnobOptions
+): T[];
+
 export interface WrapStoryProps {
     context?: object;
     storyFn?: RenderFunction;


### PR DESCRIPTION
It's possible to pass an array of default values to optionsKnob and subsequently have an array of selected options returned. This PR adds an overload type to allow that behaviour.

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] ~Add or edit tests to reflect the change. (Run with `npm test`.)~
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
